### PR TITLE
Documentation: Fixed Gradle instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Box2DLights is also available in Maven Central. Add the following dependency to 
     
 If you use Gradle, add the following dependency to your build.gradle file, in the dependencies block of the core project:
 
-     compile "com.badlogicgames.box2dlights:box2dlights:1.2"
+     compile "com.badlogicgames.box2dlights:box2dlights:1.1"
 
 ## Maintenance Note
 Box2dlights was moved from Google Code to Github to make contributing easier. The libgdx team will happily merge pull requests but will not fix bugs or ensure compatibility with the latest libgdx version.


### PR DESCRIPTION
1.2 doesn't exist in maven central, but 1.1 does.
