### PR TITLE
Adding ability to change blending

### DIFF
--- a/src/box2dLight/BlendFunc.java
+++ b/src/box2dLight/BlendFunc.java
@@ -1,0 +1,47 @@
+package box2dLight;
+
+import com.badlogic.gdx.Gdx;
+
+/**
+ * Helper class that stores source and destination factors for blending
+ */
+public class BlendFunc {
+	
+	final int default_sfactor;
+	final int default_dfactor;
+	int sfactor;
+	int dfactor;
+	
+	public BlendFunc(int sfactor, int dfactor) {
+		this.default_sfactor = sfactor;
+		this.default_dfactor = dfactor;
+		this.sfactor = sfactor;
+		this.dfactor = dfactor;
+	}
+	
+	/**
+	 * Sets source and destination blending factors
+	 */
+	public void set(int sfactor, int dfactor) {
+		this.sfactor = sfactor;
+		this.dfactor = dfactor;
+	}
+	
+	/**
+	 * Resets source and destination blending factors to default values
+	 * that were set on instance creation
+	 */
+	public void reset() {
+		sfactor = default_sfactor;
+		dfactor = default_dfactor;
+	}
+	
+	/**
+	 * Calls glBlendFunc with own source and destination factors
+	 */
+	public void apply() {
+		Gdx.gl20.glBlendFunc(sfactor, dfactor);
+	}
+	
+}
+

--- a/src/box2dLight/LightMap.java
+++ b/src/box2dLight/LightMap.java
@@ -42,17 +42,16 @@ class LightMap {
 
 		// at last lights are rendered over scene
 		if (rayHandler.shadows) {
-
 			final Color c = rayHandler.ambientLight;
 			ShaderProgram shader = shadowShader;
 			if (RayHandler.isDiffuse) {
 				shader = diffuseShader;
 				shader.begin();
-				RayHandler.diffuseBlendFunc.apply();
+				rayHandler.diffuseBlendFunc.apply();
 				shader.setUniformf("ambient", c.r, c.g, c.b, c.a);
 			} else {
 				shader.begin();
-				Gdx.gl20.glBlendFunc(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
+				rayHandler.shadowBlendFunc.apply();
 				shader.setUniformf("ambient", c.r * c.a, c.g * c.a,
 						c.b * c.a, 1f - c.a);
 			}
@@ -60,8 +59,7 @@ class LightMap {
 			lightMapMesh.render(shader, GL20.GL_TRIANGLE_FAN);
 			shader.end();
 		} else if (needed) {
-
-			Gdx.gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE);
+			rayHandler.simpleBlendFunc.apply();
 			withoutShadowShader.begin();
 		//	withoutShadowShader.setUniformi("u_texture", 0);
 			lightMapMesh.render(withoutShadowShader, GL20.GL_TRIANGLE_FAN);

--- a/src/box2dLight/RayHandler.java
+++ b/src/box2dLight/RayHandler.java
@@ -33,9 +33,27 @@ public class RayHandler implements Disposable {
 	 * TODO: remove public modifier and add getter 
 	 * */
 	public static boolean isDiffuse = false;
-	
-	/** Blend function used for diffuse lights rendering **/
-	static BlendFunc diffuseBlendFunc = BlendFunc.MULTIPLY;
+
+	/**
+	 * Blend function for lights rendering with both shadows and diffusion
+	 * <p>Default: (GL20.GL_DST_COLOR, GL20.GL_ZERO)
+	 */
+	public final BlendFunc diffuseBlendFunc =
+			new BlendFunc(GL20.GL_DST_COLOR, GL20.GL_ZERO);
+
+	/**
+	 * Blend function for lights rendering with shadows but without diffusion
+	 * <p>Default: (GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA)
+	 */
+	public final BlendFunc shadowBlendFunc =
+			new BlendFunc(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
+
+	/**
+	 * Blend function for lights rendering without shadows and diffusion 
+	 * <p>Default: (GL20.GL_SRC_ALPHA, GL20.GL_ONE)
+	 */
+	public final BlendFunc simpleBlendFunc =
+			new BlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE);
 
 	final Matrix4 combined = new Matrix4();
 	final Color ambientLight = new Color();
@@ -252,7 +270,7 @@ public class RayHandler implements Disposable {
 
 		Gdx.gl.glDepthMask(false);
 		Gdx.gl.glEnable(GL20.GL_BLEND);
-		Gdx.gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE);
+		simpleBlendFunc.apply();
 
 		boolean useLightMap = (shadows || blur); 
 		if (useLightMap) {
@@ -464,19 +482,6 @@ public class RayHandler implements Disposable {
 	}
 	
 	/**
-	 * Enables usage of diffuse algorithm and sets specified blending mode
-	 * 
-	 * <p>Default: {@link BlendFunc#MULTIPLY}
-	 * 
-	 * @param blendFunc
-	 * 			- {@link BlendFunc#MULTIPLY} or {@link BlendFunc#OVERLAY}
-	 */
-	public static void useDiffuseLight(BlendFunc blendFunc) {
-		isDiffuse = true;
-		diffuseBlendFunc = blendFunc;
-	}
-	
-	/**
 	 * Sets rendering to custom viewport with specified position and size
 	 */
 	public void useCustomViewport(int x, int y, int width, int height) {
@@ -531,28 +536,4 @@ public class RayHandler implements Disposable {
 		return lightMap.frameBuffer;
 	}
 	
-	/** Specifies (int sfactor, int dfactor) typle passed to glBlendFunc **/
-	public static enum BlendFunc {
-	
-		/** The more realistic blending model without over-burn effect **/
-		MULTIPLY(GL20.GL_DST_COLOR, GL20.GL_ZERO),
-		
-		/** Blending model for diffuse lights used in versions <= 1.2.0
-		 * Produces over-burn effect however could be still used if needed **/
-		OVERLAY(GL20.GL_DST_COLOR, GL20.GL_SRC_COLOR);
-	
-		int sfactor;
-		int dfactor;
-		
-		BlendFunc(int sfactor, int dfactor) {
-			this.sfactor = sfactor;
-			this.dfactor = dfactor;
-		}
-		
-		void apply() {
-			Gdx.gl20.glBlendFunc(sfactor, dfactor);
-		}
-		
-	}
-
 }


### PR DESCRIPTION
Implements #24

Now you can change the blending factors for all cases during runtime.
For simple rendering without shadows and diffusion:

``` java
rayHandler.simpleBlendFunc.set(sfacor, dfactor);
```

For rendering with shadows:

``` java
rayHandler.shadowBlendFunc.set(sfacor, dfactor);
```

And for rendering with shadows and diffusion, for example for over burn effect that was used by default for versions <= 1.2.0 of box2dlights, you could change diffuse blending to following values:

``` java
rayHandler.diffuseBlendFunc.set(GL20.GL_DST_COLOR, GL20.GL_SRC_COLOR);
```

To restore the default box2dlights blending factors you can just call:

``` java
rayHandler.diffuseBlendFunc.reset();
```

Was playing around with factors and found some odd effects could be achieved.
![image](https://cloud.githubusercontent.com/assets/2253795/4252231/16c261c0-3a94-11e4-953f-164017d943dd.png)
