### PR TITLE
added ability to resize the fbo

### DIFF
--- a/src/box2dLight/RayHandler.java
+++ b/src/box2dLight/RayHandler.java
@@ -73,7 +73,7 @@ public class RayHandler implements Disposable {
 	 */
 	final Array<Light> disabledLights = new Array<Light>(false, 16);
 
-	final LightMap lightMap;
+	LightMap lightMap;
 	final ShaderProgram lightShader;
 	
 	boolean culling = true;
@@ -127,8 +127,18 @@ public class RayHandler implements Disposable {
 	public RayHandler(World world, int fboWidth, int fboHeigth) {
 		this.world = world;
 
-		lightMap = new LightMap(this, fboWidth, fboHeigth);
+		resizeFBO(fboWidth, fboHeigth);
 		lightShader = LightShader.createLightShader();
+	}
+
+	/**
+	 * Resize the FBO used for intermediate rendering.
+	 */
+	public void resizeFBO(int fboWidth, int fboHeight) {
+		if (lightMap != null) {
+			lightMap.dispose();
+		}
+		lightMap = new LightMap(this, fboWidth, fboHeight);
 	}
 	
 	/**


### PR DESCRIPTION
Internal light map is no longer final, and can be resized if needed. This is useful when size of the screen changes, for example when it rotates or windows is resized on desktop.