### PR TITLE
Convert box2d body position from meters to pixels

### DIFF
--- a/src/box2dLight/PositionalLight.java
+++ b/src/box2dLight/PositionalLight.java
@@ -225,8 +225,8 @@ public abstract class PositionalLight extends Light {
 		final float sin = MathUtils.sin(angle);
 		final float dX = bodyOffsetX * cos - bodyOffsetY * sin;
 		final float dY = bodyOffsetX * sin + bodyOffsetY * cos;
-		start.x = vec.x + dX;
-		start.y = vec.y + dY;
+		start.x = vec.x * RayHandler.BOX2D_WORLD_SCALE + dX;
+		start.y = vec.y * RayHandler.BOX2D_WORLD_SCALE + dY;
 		setDirection(bodyAngleOffset + angle * MathUtils.radiansToDegrees);
 	}
 	


### PR DESCRIPTION
This solves know problems with attachToBody() method in this class. Box2d always handles meters, instead pixels:

According to Box2D manual: 

	Caution
	
	Box2D is tuned for MKS units. Keep the size of moving objects roughly between 0.1 and 10 meters.
	You'll need to use some scaling system when you render your environment and actors.
	The Box2D testbed does this by using an OpenGL viewport transform. DO NOT USE PIXELS.