### PR TITLE
soft shadow length is set to distance * 0.1 on creation of light

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+[1.5]
+- Lights soft shadow length is set to distance * 0.1 on creation.
+
 [1.4]
 - Build against LibGDX 1.6.2
 - [API Change] Light.setContactFilter(...) is now not static and light specific, the static method for all lights is now called setGlobalContactFilter(...)

--- a/src/box2dLight/ChainLight.java
+++ b/src/box2dLight/ChainLight.java
@@ -67,7 +67,7 @@ public class ChainLight extends Light {
 	 * @param color
 	 *            color, set to {@code null} to use the default color
 	 * @param distance
-	 *            distance of light
+	 *            distance of light, soft shadow length is set to distance * 0.1f
 	 * @param rayDirection
 	 *            direction of rays
 	 *            <ul>

--- a/src/box2dLight/ConeLight.java
+++ b/src/box2dLight/ConeLight.java
@@ -25,7 +25,7 @@ public class ConeLight extends PositionalLight {
 	 * @param color
 	 *            color, set to {@code null} to use the default color
 	 * @param distance
-	 *            distance of cone light
+	 *            distance of cone light, soft shadow length is set to distance * 0.1f
 	 * @param x
 	 *            axis position
 	 * @param y

--- a/src/box2dLight/Light.java
+++ b/src/box2dLight/Light.java
@@ -66,7 +66,7 @@ public abstract class Light implements Disposable {
 	 * @param color
 	 *            light color
 	 * @param distance
-	 *            light distance (if applicable)
+	 *            light distance (if applicable), soft shadow length is set to distance * 0.1f
 	 * @param directionDegree
 	 *            direction in degrees (if applicable) 
 	 */
@@ -77,6 +77,7 @@ public abstract class Light implements Disposable {
 		setRayNum(rays);
 		setColor(color);
 		setDistance(distance);
+		setSoftnessLength(distance * 0.1f);
 		setDirection(directionDegree);
 	}
 

--- a/src/box2dLight/PointLight.java
+++ b/src/box2dLight/PointLight.java
@@ -37,7 +37,7 @@ public class PointLight extends PositionalLight {
 	 * @param color
 	 *            color, set to {@code null} to use the default color
 	 * @param distance
-	 *            distance of light
+	 *            distance of light, soft shadow length is set to distance * 0.1f
 	 * @param x
 	 *            horizontal position in world coordinates
 	 * @param y


### PR DESCRIPTION
Currently softShadowLength of `Light` has hard coded default. That results in unexpected behaviour when  lights distance is near or below this value, see #79.  This change makes sure that the shadow length always has sane value.