### PR TITLE
Allow render lights in frame buffer objects

### DIFF
--- a/src/box2dLight/LightMap.java
+++ b/src/box2dLight/LightMap.java
@@ -32,9 +32,7 @@ class LightMap {
 	public void render() {
 
 		boolean needed = rayHandler.lightRenderedLastFrame > 0;
-		// this way lot less binding
-		if (needed && rayHandler.blur)
-			gaussianBlur();
+
 
 		if (lightMapDrawingDisabled)
 			return;


### PR DESCRIPTION
I needed to render lights in a frame buffer object, so I did this small refactoring.

I use it that way:

```java
rayHandler.setCombinedMatrix(cam);
rayHandler.update();
rayHandler.prepareRender();

buffer.begin();
Gdx.gl.glClearColor(1, 1, 1, 1);
Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
rayHandler.renderOnly();
buffer.end();
```