### PR TITLE
Fixed Shader compilation problems on ATI graphic cards

### DIFF
--- a/src/shaders/DiffuseShader.java
+++ b/src/shaders/DiffuseShader.java
@@ -33,9 +33,12 @@ public class DiffuseShader {
 		ShaderProgram.pedantic = false;
 		ShaderProgram shadowShader = new ShaderProgram(vertexShader,
 					fragmentShader);
-		if (shadowShader.isCompiled() == false) {
-			Gdx.app.log("ERROR", shadowShader.getLog());
-
+		if (!shadowShader.isCompiled()) {
+			shadowShader = new ShaderProgram("#version 330 core\n" +vertexShader,
+					"#version 330 core\n" +fragmentShader);
+			if(!shadowShader.isCompiled()){
+				Gdx.app.log("ERROR", shadowShader.getLog());
+			}
 		}
 
 		return shadowShader;

--- a/src/shaders/Gaussian.java
+++ b/src/shaders/Gaussian.java
@@ -64,8 +64,12 @@ public class Gaussian {
 		ShaderProgram.pedantic = false;
 		ShaderProgram blurShader = new ShaderProgram(vertexShader,
 				fragmentShader);
-		if (blurShader.isCompiled() == false) {
-			Gdx.app.log("ERROR", blurShader.getLog());
+		if (!blurShader.isCompiled()) {
+			blurShader = new ShaderProgram("#version 330 core\n" +vertexShader,
+					"#version 330 core\n" +fragmentShader);
+			if(!blurShader.isCompiled()){
+				Gdx.app.log("ERROR", blurShader.getLog());
+			}
 		}
 
 		return blurShader;

--- a/src/shaders/LightShader.java
+++ b/src/shaders/LightShader.java
@@ -37,8 +37,12 @@ public final class LightShader {
 		ShaderProgram.pedantic = false;
 		ShaderProgram lightShader = new ShaderProgram(vertexShader,
 				fragmentShader);
-		if (lightShader.isCompiled() == false) {
-			Gdx.app.log("ERROR", lightShader.getLog());
+		if (!lightShader.isCompiled()) {
+			lightShader = new ShaderProgram("#version 330 core\n" +vertexShader,
+					"#version 330 core\n" +fragmentShader);
+			if(!lightShader.isCompiled()){
+				Gdx.app.log("ERROR", lightShader.getLog());
+			}
 		}
 
 		return lightShader;

--- a/src/shaders/ShadowShader.java
+++ b/src/shaders/ShadowShader.java
@@ -32,9 +32,12 @@ public final class ShadowShader {
 		ShaderProgram.pedantic = false;
 		ShaderProgram shadowShader = new ShaderProgram(vertexShader,
 				fragmentShader);
-		if (shadowShader.isCompiled() == false) {
-			Gdx.app.log("ERROR", shadowShader.getLog());
-
+		if (!shadowShader.isCompiled()) {
+			shadowShader = new ShaderProgram("#version 330 core\n" +vertexShader,
+					"#version 330 core\n" +fragmentShader);
+			if(!shadowShader.isCompiled()){
+				Gdx.app.log("ERROR", shadowShader.getLog());
+			}
 		}
 
 		return shadowShader;

--- a/src/shaders/WithoutShadowShader.java
+++ b/src/shaders/WithoutShadowShader.java
@@ -32,9 +32,12 @@ public final class WithoutShadowShader {
 		ShaderProgram.pedantic = false;
 		ShaderProgram woShadowShader = new ShaderProgram(vertexShader,
 				fragmentShader);
-		if (woShadowShader.isCompiled() == false) {
-			Gdx.app.log("ERROR", woShadowShader.getLog());
-
+		if (!woShadowShader.isCompiled()) {
+			woShadowShader = new ShaderProgram("#version 330 core\n" +vertexShader,
+					"#version 330 core\n" +fragmentShader);
+			if(!woShadowShader.isCompiled()){
+				Gdx.app.log("ERROR", woShadowShader.getLog());
+			}
 		}
 
 		return woShadowShader;


### PR DESCRIPTION
On ATI cards given shaders does not compiled due to lack of "#version" at its beggings. When version is not given version 110 is assumed which is not compatible with GL30. Left original path of shader creation but added correction when the first one fails.