### PR TITLE
Added getters and setters for body offsets in PositionalLight

### DIFF
--- a/src/box2dLight/PositionalLight.java
+++ b/src/box2dLight/PositionalLight.java
@@ -279,5 +279,28 @@ public abstract class PositionalLight extends Light {
 		}
 		softShadowMesh.setVertices(segments, 0, size);
 	}
-	
+
+	public float getBodyOffsetX() {
+		return bodyOffsetX;
+	}
+
+	public float getBodyOffsetY() {
+		return bodyOffsetY;
+	}
+
+	public float getBodyAngleOffset() {
+		return bodyAngleOffset;
+	}
+
+	public void setBodyOffsetX(float bodyOffsetX) {
+		this.bodyOffsetX = bodyOffsetX;
+	}
+
+	public void setBodyOffsetY(float bodyOffsetY) {
+		this.bodyOffsetY = bodyOffsetY;
+	}
+
+	public void setBodyAngleOffset(float bodyAngleOffset) {
+		this.bodyAngleOffset = bodyAngleOffset;
+	}
 }


### PR DESCRIPTION
Allows for changing which way a light points, for example, while attached to a body in case the body needs to pointing another way. Current alternative is to extend the light class in question which is, last I checked, not good practice.